### PR TITLE
fixed bad namespacing

### DIFF
--- a/src/Migr8/IMigration.cs
+++ b/src/Migr8/IMigration.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Migr8.Internal
+namespace Migr8
 {
     public interface IMigration
     {

--- a/src/Migr8/Migr8.csproj
+++ b/src/Migr8/Migr8.csproj
@@ -52,7 +52,7 @@
     <Compile Include="DB\DbConnectionExtensions.cs" />
     <Compile Include="DB\ExtProp.cs" />
     <Compile Include="Internal\ISingleSqlStatement.cs" />
-    <Compile Include="Internal\IMigration.cs" />
+    <Compile Include="IMigration.cs" />
     <Compile Include="Internal\IProvideMigrations.cs" />
     <Compile Include="Migrate.cs" />
     <Compile Include="MigrationAttribute.cs" />


### PR DESCRIPTION
IMigration shouldn't be in namespace 'Migr8.Internal' as its being used together with the migration attribute (public).
Oops!
